### PR TITLE
Add missing semicolons & use PhantomJS 2.0.0 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "0.12"
 
-sudo: false
+sudo: required
 
 cache:
   directories:
@@ -22,9 +22,12 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
+  - "wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2"
+  - "tar -xjf phantomjs-2.0.0-ubuntu-12.04.tar.bz2"
+  - "sudo rm -rf /usr/local/phantomjs/bin/phantomjs"
+  - "sudo mv phantomjs /usr/local/phantomjs/bin/phantomjs"
 
 install:
   - npm install -g bower

--- a/addon/components/calendar-display.js
+++ b/addon/components/calendar-display.js
@@ -79,8 +79,8 @@ function buildWeek(month, week) {
   var daysInMonth = month.daysInMonth();
   var days = [];
   for (var i = 0; i < 7; i++) {
-    var d = (i - firstDay + week * 7)
-    days[i] = month.startOf('month').clone().add(d, 'day')
+    var d = (i - firstDay + week * 7);
+    days[i] = month.startOf('month').clone().add(d, 'day');
   }
   return days;
 }


### PR DESCRIPTION
At first, I was paranoid and thought there were some missing semicolons but the real issue is that Travis was using PhantomJS 1.9, which doesn't support Javacsript `bind`. I was under the impression that it would have used 2.0.0 by default with the Travis config generated by the Ember addon generator-- not the case. I added manual steps to the `before_install` hook that will make this happen, which indeed fixes CI.