### PR TITLE
add more node versions to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 language: node_js
 node_js:
+  - "5"
+  - "4"
   - "0.12"
 
 sudo: required

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "date-range-picker",
   "version": "0.0.0",
-  "description": "The default blueprint for ember-cli addons.",
+  "description": "Ember addon that provides various date pickers.",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -11,11 +11,11 @@
     "start": "ember server",
     "test": "ember try:testall"
   },
-  "repository": "",
+  "repository": "git@github.com:wearemolecule/date-range-picker.git",
   "engines": {
     "node": ">= 0.10.0"
   },
-  "author": "",
+  "author": "osxi",
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",


### PR DESCRIPTION
As the title suggests, I've added more Node versions for Travis to test with as per https://docs.travis-ci.com/user/languages/javascript-with-nodejs.