### PR TITLE
Fix week counting

### DIFF
--- a/addon/pods/calendar-display/component.js
+++ b/addon/pods/calendar-display/component.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend(ExpandedValidators, {
 
   weeks: computed('month', function() {
     var month = this.get('month');
-    const weeksInMonth = month.endOf('month').week() - month.startOf('month').week();
+    const weeksInMonth = Math.floor(month.daysInMonth() / 7);
     var weeks = [];
     for (var i = 0; i <= weeksInMonth; i++) {
       weeks[i] = buildWeek(month, i);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-range-picker",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Ember addon that provides various date pickers.",
   "directories": {
     "doc": "doc",

--- a/tests/integration/pods/components/date-range-picker/component-test.js
+++ b/tests/integration/pods/components/date-range-picker/component-test.js
@@ -195,6 +195,19 @@ test('apply/cancel actions', function(assert) {
   assert.equal(this.get('isExpanded'), false, 'isExpanded is toggled to false again');
 });
 
+test('can render 12/25/2015', function(assert) {
+  let today = moment('2015-12-25', 'YYYY-MM-DD');
+
+  this.set('today', today);
+
+  this.render(hbs`{{date-range-picker startMonth=today
+                                      isExpanded=true}}`);
+
+  let $leftCal = this.$('.dp-display-calendar:first');
+
+  assert.equal($leftCal.find('.dp-day').length, 35, '12/2015 has the correct number of days');
+});
+
 function allText($leftCalendar, $rightCalendar) {
   return text($leftCalendar).concat(text($rightCalendar));
 }


### PR DESCRIPTION
This PR fixes a bug where the number of weeks were being incorrectly counted, which led to December startDates rendering zero days in the calendar-display component.