### PR TITLE
fix month-picker start/end dates

### DIFF
--- a/addon/pods/month-display/component.js
+++ b/addon/pods/month-display/component.js
@@ -16,7 +16,13 @@ export default Ember.Component.extend({
     setMonth(month) {
       let day = this.get('month').date();
       let year = this.get('month').year();
-      this.set('month', moment(`${year}-${month}-${day}`, 'YYYY-MM-DD').startOf('day'));
+      let newDate =  moment(`${year}-${month}-${day}`, 'YYYY-MM-DD');
+
+      if (this.get('endOfMonth')) {
+        this.set('month', newDate.endOf('month'));
+      } else {
+        this.set('month', newDate.startOf('month'));
+      }
     },
 
     toggleIsExpanded() {

--- a/addon/pods/month-picker/template.hbs
+++ b/addon/pods/month-picker/template.hbs
@@ -23,7 +23,8 @@
       <div class="dp-display-month-year">
         {{month-display startDate=endDate
                         month=endDate
-                        isExpanded=rightMonthIsExpanded}}
+                        isExpanded=rightMonthIsExpanded
+                        endOfMonth=true}}
 
         {{year-display startDate=endDate
                        month=endDate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-range-picker",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Ember addon that provides various date pickers.",
   "directories": {
     "doc": "doc",

--- a/tests/integration/pods/components/month-picker/component-test.js
+++ b/tests/integration/pods/components/month-picker/component-test.js
@@ -164,3 +164,28 @@ test('apply/cancel actions', function(assert) {
 
   assert.equal(this.get('isExpanded'), false, 'isExpanded is toggled to false again');
 });
+
+test('picking new start & end month/year updates view/properties', function(assert) {
+  this.setProperties({
+    startDate: moment('2016-06-07'),
+    endDate: moment('2016-07-08'),
+    showInput: true,
+  });
+
+  this.render(hbs`{{month-picker startDate=startDate
+                                 endDate=endDate
+                                 showInput=showInput
+                                 isExpanded=true}}`);
+
+  let $leftCal = $(this.$('.dp-display-month-year').get(0));
+  let $rightCal = $(this.$('.dp-display-month-year').get(1));
+
+  $leftCal.find("button:contains('Feb')").click();
+  $rightCal.find("button:contains('Feb')").click();
+
+  let startDate = this.get('startDate').format('YYYY-MM-DD');
+  let endDate = this.get('endDate').format('YYYY-MM-DD');
+
+  assert.equal(startDate, '2016-02-01', 'startDate is the start of 02/2016');
+  assert.equal(endDate, '2016-02-29', 'endDate is the end of 02/2016');
+});


### PR DESCRIPTION
This PR fixes the start and end date not being set to the beginning/end of the month in the `month-picker` component.

To reproduce:
  - startDate of 01/02/2016
  - endDate of 01/03/2016
  - choose Feb on the left calendar
  - choose Feb on the right calendar

The resulting startDate is incorrectly changed to 02/02/2016 and the endDate is incorrectly changed to 02/03/2016.

The startDate should have become 02/01/2016 and the endDate 02/29/2016.