### PR TITLE
Fix out of range days when changing month

### DIFF
--- a/addon/pods/month-display/component.js
+++ b/addon/pods/month-display/component.js
@@ -14,9 +14,7 @@ export default Ember.Component.extend({
 
   actions: {
     setMonth(month) {
-      let day = this.get('month').date();
-      let year = this.get('month').year();
-      let newDate =  moment(`${year}-${month}-${day}`, 'YYYY-MM-DD');
+      let newDate = this.get('month').clone().month(month);
 
       if (this.get('endOfMonth')) {
         this.set('month', newDate.endOf('month'));

--- a/addon/pods/month-display/template.hbs
+++ b/addon/pods/month-display/template.hbs
@@ -4,8 +4,8 @@
 
 {{#if isExpanded}}
   <div class="dp-month-body">
-    {{#each allMonths as |month|}}
-      <button {{action "setMonth" month}}>
+    {{#each allMonths as |month monthIndex|}}
+      <button {{action "setMonth" monthIndex}}>
         {{friendly-month month}}
       </button>
     {{/each}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-range-picker",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Ember addon that provides various date pickers.",
   "directories": {
     "doc": "doc",

--- a/tests/integration/pods/components/month-picker/component-test.js
+++ b/tests/integration/pods/components/month-picker/component-test.js
@@ -189,3 +189,24 @@ test('picking new start & end month/year updates view/properties', function(asse
   assert.equal(startDate, '2016-02-01', 'startDate is the start of 02/2016');
   assert.equal(endDate, '2016-02-29', 'endDate is the end of 02/2016');
 });
+
+test('picking new, out-of-range startDate does not create invalid date', function(assert) {
+  this.setProperties({
+    startDate: moment('2016-03-30'),
+    endDate: moment('2016-05-05'),
+    showInput: true,
+  });
+
+  this.render(hbs`{{month-picker startDate=startDate
+                                 endDate=endDate
+                                 showInput=showInput
+                                 isExpanded=true}}`);
+
+  let $leftCal = $(this.$('.dp-display-month-year').get(0));
+
+  $leftCal.find("button:contains('Feb')").click();
+
+  let startDate = this.get('startDate').format('YYYY-MM-DD');
+
+  assert.equal(startDate, '2016-02-01', 'startDate is the start of 02/2016');
+});


### PR DESCRIPTION
Fixes a bug where choosing a new month potentially attempts to create a date with an invalid day.

For example: using a startDate of 03/30/2016 in month-picker and then selecting a start month of February will attempt to create a moment() using "02/30/2016" (invalid date).

The bug is fixed  by using moment().month() to set the month instead of creating a string and using that to create a new moment().

Note: updates package.json to reflect new version: `v0.1.4`.