### PR TITLE
add tabindex to -picker components

### DIFF
--- a/addon/pods/date-range-picker/template.hbs
+++ b/addon/pods/date-range-picker/template.hbs
@@ -4,7 +4,8 @@
                  value=rangeFormatted
                  mask="99/99/9999 - 99/99/9999"
                  focus-in="toggleIsExpanded"
-                 key-press="parseInput"}}
+                 key-press="parseInput"
+                 tabindex=1}}
   {{/if}}
 
   {{#if isExpanded}}

--- a/addon/pods/month-picker/template.hbs
+++ b/addon/pods/month-picker/template.hbs
@@ -4,7 +4,8 @@
                  mask="99/9999 - 99/9999"
                  class="dp-date-input"
                  focus-in="toggleIsExpanded"
-                 key-press="parseInput"}}
+                 key-press="parseInput"
+                 tabindex=1}}
   {{/if}}
 
   {{#if isExpanded}}

--- a/addon/pods/year-picker/template.hbs
+++ b/addon/pods/year-picker/template.hbs
@@ -4,7 +4,8 @@
                  mask="9999"
                  class="dp-date-input"
                  focus-in="toggleIsExpanded"
-                 key-press="parseInput"}}
+                 key-press="parseInput"
+                 tabindex=1}}
   {{/if}}
 
   {{#if isExpanded}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-range-picker",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Ember addon that provides various date pickers.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
This PR adds `tabindex=1` to the inputs within the `date-range-picker`, `month-picker`, and `year-picker` components so that they can be tabbed to/from within a form.