### PR TITLE
Only activate keyboard for expanded date-range-picker

### DIFF
--- a/addon/pods/date-range-picker/component.js
+++ b/addon/pods/date-range-picker/component.js
@@ -19,7 +19,7 @@ export default Component.extend(ClickOutside, Picker, Clearable, PickerActions, 
   endMonth: moment().startOf('month'),
   layout,
   startMonth: moment().startOf('month'),
-  keyboardActivated: true,
+  keyboardActivated: computed.alias('isExpanded'),
   keyboardFirstResponder: computed.alias('isExpanded'),
   focusedDay: 0,
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-range-picker",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Ember addon that provides various date pickers.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
This PR only allows keyboard shortcuts to be accepted for the `date-range-picker` while `isExpanded` is `true`, otherwise ignoring keyboard input. 