### PR TITLE
Remove dependency on lodash

### DIFF
--- a/addon/helpers/range.js
+++ b/addon/helpers/range.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+export function range(begin, end) {
+  let res = [];
+
+  if (end === undefined) {
+    end = begin;
+    begin = 0;
+  }
+
+  let asc = begin < end;
+
+  for (let cur=begin, i=0; asc ? cur < end : cur > end; asc ? cur++ : cur--, i++) {
+    res[i] = cur;
+  }
+
+  return res;
+}
+
+export default Ember.Helper.helper(range);

--- a/addon/pods/month-display/component.js
+++ b/addon/pods/month-display/component.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 import layout from './template';
-import _ from 'lodash/lodash';
+import { range } from 'date-range-picker/helpers/range';
 
 export default Ember.Component.extend({
-  allMonths: _.range(1, 13),
+  allMonths: range(1, 13),
   isExpanded: false,
   layout,
   tagName: "span",

--- a/addon/pods/year-display/component.js
+++ b/addon/pods/year-display/component.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import layout from './template';
-import _ from 'lodash/lodash';
+import { range } from 'date-range-picker/helpers/range';
 import moment from 'moment';
 import Picker from 'date-range-picker/mixins/picker';
 
@@ -19,7 +19,7 @@ export default Component.extend(Picker, {
     let year = moment().year();
     let offset = this.get('allYearsOffset');
 
-    return _.range(year - offset, year + offset + 1);
+    return range(year - offset, year + offset + 1);
   }),
 
   actions: {

--- a/app/pods/range/helper.js
+++ b/app/pods/range/helper.js
@@ -1,0 +1,1 @@
+export { default, range } from 'date-range-picker/range/helper';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-range-picker",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "description": "Ember addon that provides various date pickers.",
   "directories": {
     "doc": "doc",
@@ -35,7 +35,6 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-load-initializers": "^0.5.0",
-    "ember-lodash": "0.0.6",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.1.2",
     "loader.js": "^4.0.0"

--- a/tests/unit/helpers/friendly-month-test.js
+++ b/tests/unit/helpers/friendly-month-test.js
@@ -1,11 +1,11 @@
 import { friendlyMonth } from 'dummy/helpers/friendly-month';
 import { module, test } from 'qunit';
-import _ from 'lodash/lodash';
+import { range } from 'date-range-picker/helpers/range';
 
 module('Unit | Helper | friendly month');
 
 test('it works', function(assert) {
-  let actualMonths = _.range(1, 13).map(monthIndex => friendlyMonth(monthIndex));
+  let actualMonths = range(1, 13).map(monthIndex => friendlyMonth(monthIndex));
 
   let expectedMonths = [
     'Jan',

--- a/tests/unit/helpers/range-test.js
+++ b/tests/unit/helpers/range-test.js
@@ -1,0 +1,13 @@
+import { range } from 'date-range-picker/helpers/range';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | range');
+
+test('it works', function(assert) {
+  // Derived from https://lodash.com/docs#range
+
+  assert.deepEqual(range(4), [0, 1, 2, 3]);
+  assert.deepEqual(range(-4), [0, -1, -2, -3]);
+  assert.deepEqual(range(1, 5), [1, 2, 3, 4]);
+  assert.deepEqual(range(0), []);
+});


### PR DESCRIPTION
This PR removes Lodash and replaces the usage of `range` with an Ember helper that behaves similarly but intentionally does not support the third (`step`) argument.

I went ahead and used v0.1.10 instead of v0.1.9 because that tag already exists and I'd rather not break anything by updating an existing tag.