### PR TITLE
Bump ember-cli-htmlbars ver; change name to ember-date-range-picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,7 @@
 # Date-range-picker [![Build Status](https://travis-ci.org/wearemolecule/date-range-picker.svg?branch=master)](https://travis-ci.org/wearemolecule/date-range-picker)
 
-This README outlines the details of collaborating on this Ember addon.
+`ember install ember-date-range-picker`
 
-## Installation
+This addon provides a collection of components for picking dates and ranges of dates. For documentation and a demonstration of the various components, please visit the [DEMO](https://wearemolecule.github.io/date-range-picker).
 
-* `git clone` this repository
-* `npm install`
-* `bower install`
-
-## Running
-
-* `ember server`
-* Visit your app at http://localhost:4200.
-
-## Running Tests
-
-* `npm test` (Runs `ember try:testall` to test your addon against multiple Ember versions)
-* `ember test`
-* `ember test --server`
-
-## Building
-
-* `ember build`
-
-For more information on using ember-cli, visit [http://www.ember-cli.com/](http://www.ember-cli.com/).
+Please open an issue or create a PR if you would like to contribute!

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "date-range-picker",
+  "name": "ember-date-range-picker",
   "version": "0.1.10",
   "description": "Ember addon that provides various date pickers.",
   "directories": {
@@ -15,7 +15,7 @@
   "engines": {
     "node": ">= 0.10.0"
   },
-  "author": "osxi",
+  "author": "osxi <zach@molecule.io>",
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-cli-htmlbars": "^1.0.1",
+    "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-sass": "5.3.0",
     "ember-click-outside": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-sass": "5.3.0",
-    "ember-click-outside": "0.0.3",
+    "ember-click-outside": "^0.1.0",
     "ember-inputmask": "0.3.0",
     "ember-moment": "6.0.0",
     "ember-keyboard": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-date-range-picker",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "Ember addon that provides various date pickers.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
#This PR:
  - Changes the addon name to "ember-date-range-picker" since "date-range-picker" is taken :)
  - Bumps ember-cli-htmlbars to ^1.0.10 to remove deprecation warning introduced by Ember 2.7.0
  - Updates ember-click-outside so that it can use ember-cli-htmlbars ^1.0.10 to remove deprecation warning introduced by Ember 2.7.0

TODO:
  - [X] Wait for ember-click-outside to merge https://github.com/zeppelin/ember-click-outside/pull/4 & update the version in package.json accordingly
  - [X] Put useful information in the README (currently marked as WIP due to this on EmberObserver)