### PR TITLE
Prevent duplicate focus/opening

### DIFF
--- a/addon/mixins/picker.js
+++ b/addon/mixins/picker.js
@@ -100,7 +100,7 @@ export default Mixin.create(CancelableMixin, {
   }),
 
   focusOnInput() {
-    let element = document.querySelector("." + this.get('topClass') + " .dp-date-input");
+    let element = this.$(`.${this.get('topClass')} .dp-date-input`).get(0);
     if (this.$(element)) {
       this.$(element).focus();
       this.$(element).select();

--- a/addon/mixins/picker.js
+++ b/addon/mixins/picker.js
@@ -100,11 +100,7 @@ export default Mixin.create(CancelableMixin, {
   }),
 
   focusOnInput() {
-    let element = this.$(`.${this.get('topClass')} .dp-date-input`).get(0);
-    if (this.$(element)) {
-      this.$(element).focus();
-      this.$(element).select();
-    }
+    this.$(`.${this.get('topClass')} .dp-date-input`).first().focus().select();
   },
 
   actions: {


### PR DESCRIPTION
This PR fixes a bug where two date-range-picker components will open when clicking on the last one in the page due to a lack of selector scope.

To reproduce: 
  - Put two date-range-picker components on a page
  - Click second one
  - First one will receive focus and second one will open