### PR TITLE
Removing Left/Right arrow keys and sorting start/end from input

### DIFF
--- a/addon/mixins/cancelable.js
+++ b/addon/mixins/cancelable.js
@@ -1,21 +1,16 @@
 import Ember from 'ember';
+import moment from 'moment';
+import SafeMoment from 'date-range-picker/mixins/safe-moment';
 
 const { computed, run } = Ember;
 
-export default Ember.Mixin.create({
+export default Ember.Mixin.create(SafeMoment, {
   resetInitialValues() {
-    let {
-      startDate,
-      endDate,
-      startMonth,
-      endMonth
-    } = this.getProperties('startDate', 'endDate', 'startMonth', 'endMonth');
-
     this.setProperties({
-      initialStartDate: startDate.clone(),
+      initialStartDate: this.safeClone('startDate'),
       initialEndDate: this.safeClone('endDate'),
-      initialStartMonth: startMonth.clone(),
-      initialEndMonth: endMonth.clone()
+      initialStartMonth: this.safeClone('startMonth', moment().startOf('month')),
+      initialEndMonth: this.safeClone('endMonth', moment().startOf('month'))
     });
 
     run.next(this, () => {
@@ -33,28 +28,13 @@ export default Ember.Mixin.create({
       this.safeIsSame('endMonth', 'initialEndMonth');
   }),
 
-  safeIsSame(first, second) {
-    if (!this.get(first) || !this.get(second)) {
-      return false;
-    }
-
-    return this.get(first).isSame(this.get(second));
-  },
-
-  safeClone(date) {
-    if (!this.get(date)) {
-      return null;
-    }
-    return this.get(date).clone();
-  },
-
   actions: {
     reset() {
       this.setProperties({
-        startDate: this.get('initialStartDate').clone(),
+        startDate: this.safeClone('initialStartDate'),
         endDate: this.safeClone('initialEndDate'),
-        startMonth: this.get('initialStartMonth').clone(),
-        endMonth: this.get('initialEndMonth').clone(),
+        startMonth: this.safeClone('initialStartMonth', moment().startOf('month')),
+        endMonth: this.safeClone('initialEndMonth', moment().startOf('month')),
       });
     },
 

--- a/addon/mixins/keyboard-hotkeys.js
+++ b/addon/mixins/keyboard-hotkeys.js
@@ -21,14 +21,6 @@ export default Mixin.create(EKMixin, {
     this.onTriggerEscape();
   }),
 
-  _leftArrowHandler: on(keyDown('ArrowLeft'), function() {
-    this.onTriggerArrowUp();
-  }),
-
-  _rightArrowHandler: on(keyDown('ArrowRight'), function() {
-    this.onTriggerArrowDown();
-  }),
-
   _downArrowHandler: on(keyDown('ArrowDown'), function() {
     this.onTriggerArrowDown();
   }),

--- a/addon/mixins/picker.js
+++ b/addon/mixins/picker.js
@@ -97,7 +97,12 @@ export default Mixin.create(CancelableMixin, {
           endMonth: endMoment.clone().startOf('month'),
         });
       } else {
-        this.set('endDate', null);
+        this.setProperties({
+          startDate: moment(),
+          endDate: moment(),
+          startMonth: moment().startOf('month'),
+          endMonth: moment().startOf('month'),
+        });
       }
 
       return v;

--- a/addon/mixins/picker.js
+++ b/addon/mixins/picker.js
@@ -66,8 +66,9 @@ export default Mixin.create(CancelableMixin, {
 
     set(k, v) {
       let [ start, end ] = v.split('—');
-      let startMoment = moment(start, this.get('dateFormat'));
-      let endMoment = moment(end, this.get('dateFormat'));
+      let dateFormat = this.get('dateFormat');
+      let startMoment = moment(start, dateFormat);
+      let endMoment = moment(end, dateFormat);
 
       if(startMoment.isValid() || endMoment.isValid()) {
         if(!endMoment.isValid()) {
@@ -81,6 +82,10 @@ export default Mixin.create(CancelableMixin, {
         if (this.get('hasDateParseOverride')) {
           startMoment = this.overrideStartDateParse(startMoment);
           endMoment = this.overrideEndDateParse(endMoment);
+        }
+
+        if (startMoment.isAfter(endMoment)) {
+          [startMoment, endMoment] = [endMoment.clone(), startMoment.clone()];
         }
       }
 

--- a/addon/mixins/picker.js
+++ b/addon/mixins/picker.js
@@ -1,13 +1,14 @@
 import Ember from 'ember';
-import moment from 'moment';
 import CancelableMixin from 'date-range-picker/mixins/cancelable';
+import SafeMoment from 'date-range-picker/mixins/safe-moment';
+import moment from 'moment';
 
 const {
   isBlank,
   Mixin,
 } = Ember;
 
-export default Mixin.create(CancelableMixin, {
+export default Mixin.create(CancelableMixin, SafeMoment,  {
   classNameBindings: ['topClass'],
   topClass: 'dp-date-range-picker',
   showInput: true,
@@ -29,16 +30,9 @@ export default Mixin.create(CancelableMixin, {
   didReceiveAttrs() {
     this._super(...arguments);
     let startDate = this.get('startDate');
-    let startIsBlank = isBlank(startDate);
 
     if (typeof startDate === 'string') {
       startDate = this.set('startDate', moment(startDate));
-    }
-
-    if (startIsBlank) {
-      this.set('startDate', moment(startDate, this.get('dateFormat')).startOf('day'));
-    } else if (startDate && !startDate._isAMomentObject) {
-      this.set('startDate', moment().startOf(this.get('defaultStart')).startOf('day'));
     }
 
     let endDate = this.get('endDate');
@@ -50,16 +44,20 @@ export default Mixin.create(CancelableMixin, {
       this.resetInitialValues();
     }
 
-    this.set('startMonth', this.get('startDate').clone().startOf('month'));
-    if (this.get('endDate')) {
-      this.set('endMonth', this.get('endDate').clone().startOf('month'));
-    }
+    this.updateStartAndEndMonth();
+  },
+
+  updateStartAndEndMonth: function() {
+    this.setProperties({
+      startMonth: this.safeClone('startDate', moment().startOf('month')),
+      endMonth: this.safeClone('endDate', moment().startOf('month'))
+    });
   },
 
   rangeFormatted: Ember.computed('startDate', 'endDate', 'dateFormat', {
     get() {
       let dateFormat = this.get('dateFormat');
-      let startDate = this.get('startDate').format(dateFormat);
+      let startDate = this.get('startDate') ? this.get('startDate').format(dateFormat) : '';
       let endDate = this.get('endDate') ? this.get('endDate').format(dateFormat) : '';
       return `${startDate}—${endDate}`;
     },
@@ -70,40 +68,28 @@ export default Mixin.create(CancelableMixin, {
       let startMoment = moment(start, dateFormat);
       let endMoment = moment(end, dateFormat);
 
-      if(startMoment.isValid() || endMoment.isValid()) {
-        if(!endMoment.isValid()) {
-          endMoment = startMoment.clone().endOf(this.get('defaultEnd')).startOf('day');
-        }
-
-        if(!startMoment.isValid()) {
-          startMoment = endMoment.clone().startOf(this.get('defaultStart')).startOf('day');
-        }
-
-        if (this.get('hasDateParseOverride')) {
-          startMoment = this.overrideStartDateParse(startMoment);
-          endMoment = this.overrideEndDateParse(endMoment);
-        }
-
-        if (startMoment.isAfter(endMoment)) {
-          [startMoment, endMoment] = [endMoment.clone(), startMoment.clone()];
-        }
+      if (this.get('hasDateParseOverride')) {
+        startMoment = this.overrideStartDateParse(startMoment);
+        endMoment = this.overrideEndDateParse(endMoment);
       }
 
-      if (startMoment.isValid() && endMoment.isValid()) {
-        this.setProperties({
-          startDate: startMoment,
-          endDate: endMoment,
-          startMonth: startMoment.clone().startOf('month'),
-          endMonth: endMoment.clone().startOf('month'),
-        });
+      if (startMoment.isAfter(endMoment)) {
+        [startMoment, endMoment] = [endMoment.clone(), startMoment.clone()];
+      }
+
+      if (startMoment && startMoment.isValid()) {
+        this.set('startDate', startMoment);
       } else {
-        this.setProperties({
-          startDate: moment(),
-          endDate: moment(),
-          startMonth: moment().startOf('month'),
-          endMonth: moment().startOf('month'),
-        });
+        this.set('startDate', null);
       }
+
+      if (endMoment && endMoment.isValid()) {
+        this.set('endDate', endMoment);
+      } else {
+        this.set('endDate', null);
+      }
+
+      this.updateStartAndEndMonth();
 
       return v;
     },

--- a/addon/mixins/safe-moment.js
+++ b/addon/mixins/safe-moment.js
@@ -1,0 +1,20 @@
+import moment from 'moment';
+
+export default Ember.Mixin.create({
+  safeIsSame(first, second) {
+    let one = this.get(first);
+    let two = this.get(second);
+    if (!one || !two) {
+      return false;
+    }
+
+    return one.isSame(two, 'day');
+  },
+
+  safeClone(date, defaultCloneValue = null) {
+    if (!this.get(date)) {
+      return defaultCloneValue;
+    }
+    return this.get(date).clone();
+  },
+});

--- a/addon/pods/calendar-display/component.js
+++ b/addon/pods/calendar-display/component.js
@@ -2,12 +2,13 @@ import Ember from 'ember';
 import layout from './template';
 import ExpandedValidators from 'date-range-picker/mixins/expanded-validators';
 import { buildWeek } from 'date-range-picker/helpers/build-week';
+import moment from 'moment';
 
 const { computed } = Ember;
 
 export default Ember.Component.extend(ExpandedValidators, {
   layout,
-  month: computed.alias('startDate'),
+  month: moment().startOf('month'),
   selectionEnd: null,
   selectionStart: null,
 

--- a/addon/pods/date-range-picker/component.js
+++ b/addon/pods/date-range-picker/component.js
@@ -137,7 +137,7 @@ export default Component.extend(Picker, KeyboardHotkeys, {
       }
 
       this.set('endDate', day);
-      this.set('endMonth', day.clone().startOf('month'));
+      this.updateStartAndEndMonth();
     },
 
     nextEndMonth() {
@@ -168,7 +168,7 @@ export default Component.extend(Picker, KeyboardHotkeys, {
       }
 
       this.set('startDate', day);
-      this.set('startMonth', day.clone().startOf('month'));
+      this.updateStartAndEndMonth();
     },
   }
 });

--- a/addon/pods/year-picker/component.js
+++ b/addon/pods/year-picker/component.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import layout from './template';
 import Picker from 'date-range-picker/mixins/picker';
 import KeyboardHotkeys from 'date-range-picker/mixins/keyboard-hotkeys';
+import SafeMoment from 'date-range-picker/mixins/safe-moment';
 import moment from 'moment';
 
 const {
@@ -10,7 +11,7 @@ const {
   Component,
 } = Ember;
 
-export default Component.extend(Picker, KeyboardHotkeys, {
+export default Component.extend(Picker, KeyboardHotkeys, SafeMoment, {
   layout,
   dateFormat: "YYYY",
   defaultStart: 'year',
@@ -42,13 +43,19 @@ export default Component.extend(Picker, KeyboardHotkeys, {
     }
   }),
 
-  rangeFormatted: computed('startDate', 'endDate', 'dateFormat', 'energyYear', function() {
-    let dateFormat = this.get('dateFormat');
-    if (this.get('energyYear')) {
+  rangeFormatted: computed('startDate', 'endDate', 'dateFormat', 'energyYear', {
+    get() {
+      let dateFormat = this.get('dateFormat');
       let date = this.get('endDate') ? this.get('endDate').format(dateFormat) : '';
-      return "EY " + date;
-    } else {
-      return this.get('startDate').format(dateFormat);
+      if (this.get('energyYear')) {
+        return "EY " + date;
+      } else {
+        return date;
+      }
+    },
+
+    set() {
+      this._super(...arguments);
     }
   }),
 
@@ -57,7 +64,7 @@ export default Component.extend(Picker, KeyboardHotkeys, {
   }),
 
   overrideStartDateParse(startDate) {
-    if (this.get('energyYear')) {
+    if (this.get('energyYear') && startDate && startDate.isValid()) {
       return moment(`${startDate.year() - 1}-${6}-${1}`, "YYYY-MM-DD");
     } else {
       return null;
@@ -65,7 +72,7 @@ export default Component.extend(Picker, KeyboardHotkeys, {
   },
 
   overrideEndDateParse(endDate) {
-    if (this.get('energyYear')) {
+    if (this.get('energyYear') && endDate && endDate.isValid()) {
       return moment(`${endDate.year()}-${5}-${31}`, "YYYY-MM-DD");
     } else {
       return null;

--- a/app/styles/date-range-picker.scss
+++ b/app/styles/date-range-picker.scss
@@ -218,6 +218,10 @@ body {
       background-color: $day-selected-color;
     }
 
+    &.dp-selected.dp-end {
+      background-color: darken($day-selected-color, 10%);
+    }
+
     &.dp-in-range {
       background-color: $day-in-range-color;
     }
@@ -226,6 +230,51 @@ body {
       background-color: $day-other-month-color;
       color: $day-other-month-txt-color;
     }
+  }
+}
+
+.dp-start {
+  position: relative;
+  padding-right: 3px;
+
+  &::before {
+    content: "";
+    width: 3px;
+    position: absolute;
+    top: 0;
+    left: -3px;
+    bottom: 0;
+    border-top-left-radius: 3px;
+    border-bottom-left-radius: 3px;
+    background-color: $day-selected-color;
+  }
+
+  &.dp-end {
+    border-radius: 0 !important;
+    background-color: $day-selected-color !important;
+
+    &::before,
+    &::after {
+      display: none !important;
+      background-color: $day-selected-color;
+    }
+  }
+}
+
+.dp-end {
+  position: relative;
+  padding-left: 3px;
+
+  &::before {
+    content: "";
+    width: 3px;
+    position: absolute;
+    top: 0;
+    right: -3px;
+    bottom: 0;
+    border-top-right-radius: 3px;
+    border-bottom-right-radius: 3px;
+    background-color: darken($day-selected-color, 10%);
   }
 }
 
@@ -383,6 +432,7 @@ body {
 }
 
 .dp-preset-picker {}
+
 
 
 // Responsive /////////////////

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-date-range-picker",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Ember addon that provides various date pickers.",
   "directories": {
     "doc": "doc",

--- a/tests/unit/mixins/picker-test.js
+++ b/tests/unit/mixins/picker-test.js
@@ -3,6 +3,22 @@ import PickerMixin from 'date-range-picker/mixins/picker';
 import { module, test } from 'qunit';
 import moment from 'moment';
 
+function safeIsSame(first, second) {
+  if (!first || !second) {
+    return first === second;
+  }
+
+  return first.isSame(second, 'day');
+}
+
+function safeFormat(day, format) {
+  if (day && day.isValid()) {
+    return day.format(format);
+  } else {
+    return day;
+  }
+}
+
 module('Unit | Mixin | picker');
 const PickerObject = Ember.Object.extend(PickerMixin);
 
@@ -18,14 +34,14 @@ test('#rangeFormatted - set', function(assert) {
 
   let testCases = [
     // Valid Start Date Supplied but no End Date
-    { rangeFormatted: "6/16/16—_/_/__", startDate: moment("6/16/16", format), endDate: moment("6/16/16", format) },
-    { rangeFormatted: "06/6/16—_/_/__", startDate: moment("06/6/16", format), endDate: moment("06/6/16", format) },
-    { rangeFormatted: "06/16/2016—_/_/__", startDate: moment("06/16/2016", format), endDate: moment("06/16/2016", format) },
+    { rangeFormatted: "6/16/16—_/_/__", startDate: moment("6/16/16", format), endDate: null },
+    { rangeFormatted: "06/6/16—_/_/__", startDate: moment("06/6/16", format), endDate: null },
+    { rangeFormatted: "06/16/2016—_/_/__", startDate: moment("06/16/2016", format), endDate: null },
 
     // Valid End Date Supplied but no Start Date
-    { rangeFormatted: "_/__/__—6/16/16", startDate: moment("6/16/16", format), endDate: moment("6/16/16", format) },
-    { rangeFormatted: "_/_/__—06/6/16", startDate: moment("06/6/16", format), endDate: moment("06/6/16", format) },
-    { rangeFormatted: "_/_/__—06/16/2016", startDate: moment("06/16/2016", format), endDate: moment("06/16/2016", format) },
+    { rangeFormatted: "_/__/__—6/16/16", startDate: null, endDate: moment("6/16/16", format) },
+    { rangeFormatted: "_/_/__—06/6/16", startDate: null, endDate: moment("06/6/16", format) },
+    { rangeFormatted: "_/_/__—06/16/2016", startDate: null, endDate: moment("06/16/2016", format) },
 
     // Valid Start and End Date supplied
     { rangeFormatted: "5/15/15—6/16/16", startDate: moment("5/15/15", format), endDate: moment("6/16/16", format) },
@@ -34,11 +50,11 @@ test('#rangeFormatted - set', function(assert) {
 
     // TODO
     // Invalid Start and End Date supplied
-    { rangeFormatted: "_/_/__—_/_/__", startDate: moment(), endDate: moment() },
-    { rangeFormatted: "0/0/00—0/0/00", startDate: moment(), endDate: moment() },
-    { rangeFormatted: "99/99/9999—99/99/9999", startDate: moment(), endDate: moment() },
-    { rangeFormatted: "5/_/__—_/_/__", startDate: moment(`05/01/${currentYear}`, format), endDate: moment(`05/01/${currentYear}`, format) },
-    { rangeFormatted: "5/15/__—_/_/__", startDate: moment(`05/15/${currentYear}`, format), endDate: moment(`05/15/${currentYear}`, format) },
+    { rangeFormatted: "_/_/__—_/_/__", startDate: null, endDate: null },
+    { rangeFormatted: "0/0/00—0/0/00", startDate: null, endDate: null },
+    { rangeFormatted: "99/99/9999—99/99/9999", startDate: null, endDate: null },
+    { rangeFormatted: "5/_/__—_/_/__", startDate: moment(`05/01/${currentYear}`, format), endDate: null },
+    { rangeFormatted: "5/15/__—_/_/__", startDate: moment(`05/15/${currentYear}`, format), endDate: null },
 
     // End Date Occurs Before Start Date
     { rangeFormatted: "5/15/16—4/1/15", startDate: moment(`04/1/2015`, format), endDate: moment(`05/15/2016`, format) },
@@ -50,13 +66,13 @@ test('#rangeFormatted - set', function(assert) {
     });
 
     assert.equal(subject.get('rangeFormatted'), criteria.rangeFormatted);
-    assert.ok(subject.get('startDate').isSame(criteria.startDate, 'day'),
+    assert.ok(safeIsSame(subject.get('startDate'), criteria.startDate),
               "Start Date for " + criteria.rangeFormatted +
-              " should be " + criteria.startDate.format(format) +
-              " but received " + subject.get('startDate').format(format));
-    assert.ok(subject.get('endDate').isSame(criteria.endDate, 'day'),
+              " should be " + safeFormat(criteria.startDate, format) +
+              " but received " + safeFormat(subject.get('startDate'), format));
+    assert.ok(safeIsSame(subject.get('endDate'), criteria.endDate),
               "End Date for " + criteria.rangeFormatted +
-              " should be " + criteria.endDate.format(format) +
-              " but received " + subject.get('endDate').format(format));
+              " should be " + safeFormat(criteria.endDate, format) +
+              " but received " + safeFormat(subject.get('endDate'), format));
   });
 });

--- a/tests/unit/mixins/picker-test.js
+++ b/tests/unit/mixins/picker-test.js
@@ -14,6 +14,7 @@ test('it can be mixed into an Ember.Object', function(assert) {
 test('#rangeFormatted - set', function(assert) {
   let PickerActionsObject = Ember.Component.extend(PickerMixin);
   let format = "MM/DD/YYYY";
+  let currentYear = moment().format("YYYY");
 
   let testCases = [
     // Valid Start Date Supplied but no End Date
@@ -32,12 +33,15 @@ test('#rangeFormatted - set', function(assert) {
     { rangeFormatted: "05/15/2015—06/16/2016", startDate: moment("05/15/2015", format), endDate: moment("06/16/2016", format) },
 
     // TODO
-    // // Invalid Start and End Date supplied
-    // { rangeFormatted: "_/_/__—_/_/__", startDate: moment().startOf('year'), endDate: moment().endOf('year') },
-    // { rangeFormatted: "0/0/00—0/0/00", startDate: moment().startOf('year'), endDate: moment().endOf('year') },
-    // { rangeFormatted: "99/99/9999—99/99/9999", startDate: moment().startOf('year'), endDate: moment().endOf('year') },
-    // { rangeFormatted: "5/_/__—_/_/__", startDate: moment(`05/01/${currentYear}`, format), endDate: moment(`05/01/${currentYear}`, format) },
-    // { rangeFormatted: "5/15/__—_/_/__", startDate: moment(`05/15/${currentYear}`, format), endDate: moment(`05/15/${currentYear}`, format) },
+    // Invalid Start and End Date supplied
+    { rangeFormatted: "_/_/__—_/_/__", startDate: moment(), endDate: moment() },
+    { rangeFormatted: "0/0/00—0/0/00", startDate: moment(), endDate: moment() },
+    { rangeFormatted: "99/99/9999—99/99/9999", startDate: moment(), endDate: moment() },
+    { rangeFormatted: "5/_/__—_/_/__", startDate: moment(`05/01/${currentYear}`, format), endDate: moment(`05/01/${currentYear}`, format) },
+    { rangeFormatted: "5/15/__—_/_/__", startDate: moment(`05/15/${currentYear}`, format), endDate: moment(`05/15/${currentYear}`, format) },
+
+    // End Date Occurs Before Start Date
+    { rangeFormatted: "5/15/16—4/1/15", startDate: moment(`04/1/2015`, format), endDate: moment(`05/15/2016`, format) },
   ];
 
   testCases.forEach(criteria => {


### PR DESCRIPTION
To fulfill an edge case bug where a user could modify the end date in the inbox to occur before the start date. While testing realized that the keyboard shortcuts for left/right made it hard to modify text in the input box. https://www.pivotaltracker.com/story/show/130568069