### PR TITLE
Fix tests

### DIFF
--- a/tests/integration/pods/components/calendar-display/component-test.js
+++ b/tests/integration/pods/components/calendar-display/component-test.js
@@ -26,7 +26,7 @@ test('actions - daySelected', function(assert) {
                                      startDate=today
                                      daySelected=(action daySelected)}}`);
 
-  let $tenthDay = this.$(".dp-day:contains('10')");
+  let $tenthDay = this.$(".dp-day:contains('10')").not('.dp-other-month');
 
   $tenthDay.click();
 });


### PR DESCRIPTION
Fixes broken test in master.

The fail was due to selecting an element that exists twice depending on the current month/year. Increasing the specificity of the selection fixes this.