### PR TITLE
Generate Year Range from Selection; Auto Scroll to Selected Year

### DIFF
--- a/addon/pods/year-display/component.js
+++ b/addon/pods/year-display/component.js
@@ -6,6 +6,7 @@ import moment from 'moment';
 const {
   computed,
   Component,
+  run,
 } = Ember;
 
 export default Component.extend({
@@ -16,8 +17,22 @@ export default Component.extend({
   month: moment(),
   energyYear: false,
 
+  didRender() {
+    if (this.get('isExpanded')) {
+      let year = this.get('insideYearPicker') ? this.get('startDate').year() : this.get('month').year();
+      let $container = this.$('.dp-year-body');
+      let $scrollTo = this.$(`button.dp-btn-year-option:contains(${year})`);
+      $container.scrollTop(
+        $scrollTo.offset().top - $container.offset().top + $container.scrollTop()
+      );
+      $container.animate({
+        scrollTop: $scrollTo.offset().top - $container.offset().top + $container.scrollTop()
+      });
+    }
+  },
+
   allYears: computed('startDate', function() {
-    let year = moment().year();
+    let year = this.get('insideYearPicker') ? this.get('startDate').year() : this.get('month').year();
     let offset = this.get('allYearsOffset');
 
     return range(year - offset, year + offset + 1);

--- a/addon/pods/year-display/component.js
+++ b/addon/pods/year-display/component.js
@@ -6,7 +6,6 @@ import moment from 'moment';
 const {
   computed,
   Component,
-  run,
 } = Ember;
 
 export default Component.extend({
@@ -27,11 +26,11 @@ export default Component.extend({
       );
       $container.animate({
         scrollTop: $scrollTo.offset().top - $container.offset().top + $container.scrollTop()
-      });
+      }, 0);
     }
   },
 
-  allYears: computed('startDate', function() {
+  allYears: computed('startDate', 'insideYearPicker', 'allYearsOffset', 'month', function() {
     let year = this.get('insideYearPicker') ? this.get('startDate').year() : this.get('month').year();
     let offset = this.get('allYearsOffset');
 

--- a/addon/pods/year-display/template.hbs
+++ b/addon/pods/year-display/template.hbs
@@ -11,7 +11,7 @@
 {{#if isExpanded}}
   <div class="dp-year-body">
     {{#each allYears as |year|}}
-      <button {{action "setYear" year}}>
+      <button {{action "setYear" year}} class="dp-btn-year-option">
         {{#if energyYear}}
           EY {{year}}
         {{else}}

--- a/addon/pods/year-picker/template.hbs
+++ b/addon/pods/year-picker/template.hbs
@@ -25,7 +25,8 @@
                      hideButton=true
                      isExpanded=true
                      ignoreMonthAndDay=true
-                     energyYear=energyYear}}
+                     energyYear=energyYear
+                     insideYearPicker=true}}
     </div>
 
     <div class="dp-action-console">

--- a/tests/integration/pods/components/date-range-picker/component-test.js
+++ b/tests/integration/pods/components/date-range-picker/component-test.js
@@ -211,6 +211,26 @@ test('converts strings to moments', function(assert) {
   assert.equal(rightYear, dateStringMoment.format(yearFormat), 'endDate year is intitial value.');
 });
 
+test('automatically scrolls to selected year', function(assert) {
+  let dateString = '3015-01-02';
+
+  this.setProperties({
+    startDate: dateString,
+    endDate: dateString,
+  });
+
+  this.render(hbs`{{date-range-picker startDate=startDate
+                                      endDate=startDate
+                                      initiallyOpened=true}}`);
+
+  this.$('.dp-btn-year').first().click();
+
+  let $btn = this.$(`.dp-calendar-header:first .dp-btn-year-option:contains('3015'):visible`);
+  let parentHeight = $btn.parent().height();
+  let parentScrollTop = $btn.parent().scrollTop();
+  assert.equal($btn.length, 1);
+  assert.equal($btn.offset().top < (parentHeight + parentScrollTop), true, 'selected year is visible');
+});
 function allText($leftCalendar, $rightCalendar) {
   return text($leftCalendar).concat(text($rightCalendar));
 }

--- a/tests/integration/pods/components/year-picker/component-test.js
+++ b/tests/integration/pods/components/year-picker/component-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
+import wait from 'ember-test-helpers/wait';
 
 moduleForComponent('year-picker', 'Integration | Component | year picker', {
   integration: true
@@ -142,6 +143,27 @@ test('converts strings to moments', function(assert) {
                                 initiallyOpened=true}}`);
 
   assert.equal(this.$(".dp-year-picker input").eq(0).val(), expectedDate);
+});
+
+test('automatically scrolls to selected year', function(assert) {
+  let dateString = '2010-04-24';
+
+  this.setProperties({
+    startDate: dateString,
+    endDate: dateString,
+  });
+
+  this.render(hbs`{{year-picker startDate=startDate
+                                endDate=endDate
+                                initiallyOpened=true}}`);
+
+  return wait().then(() => {
+    let $btn = this.$(`.dp-btn-year-option:contains('2010'):visible`);
+    let parentHeight = $btn.parent().height();
+    let parentScrollTop = $btn.parent().scrollTop();
+    assert.equal($btn.length, 1);
+    assert.equal($btn.offset().top < (parentHeight + parentScrollTop), true, 'selected year is visible');
+  });
 });
 
 function inputExpectations(assert, prefix) {


### PR DESCRIPTION
This PR:
  - Displays a range of dates around the currently selected year instead of the current year from `moment()` (in year-display components)
  - Automatically scroll to the selected year (in year-display components)