### PR TITLE
Fix month display when input is empty

### DIFF
--- a/addon/mixins/picker.js
+++ b/addon/mixins/picker.js
@@ -4,7 +4,6 @@ import SafeMoment from 'date-range-picker/mixins/safe-moment';
 import moment from 'moment';
 
 const {
-  isBlank,
   Mixin,
 } = Ember;
 

--- a/addon/pods/month-display/component.js
+++ b/addon/pods/month-display/component.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import layout from './template';
 import { range } from 'date-range-picker/helpers/range';
+import moment from 'moment';
 
 export default Ember.Component.extend({
   allMonths: range(1, 13),
@@ -33,13 +34,19 @@ export default Ember.Component.extend({
 
   actions: {
     setMonth(month) {
+      let oldMonth = this.get('month');
+      if (!oldMonth) {
+        oldMonth = moment();
+      }
+      oldMonth = oldMonth.clone().month(month);
+
       if (this.get('endOfMonth')) {
-        this.set('month', this.get('month').clone().month(month).endOf('month'));
+        this.set('month', oldMonth.endOf('month'));
       } else {
-        this.set('month', this.get('month').clone().month(month).startOf('month'));
+        this.set('month', oldMonth.startOf('month'));
       }
 
-      if(this.get('monthWasSelected')) {
+      if (this.get('monthWasSelected')) {
         this.sendAction('monthWasSelected');
       }
     },

--- a/addon/pods/month-display/component.js
+++ b/addon/pods/month-display/component.js
@@ -12,10 +12,13 @@ export default Ember.Component.extend({
     if (this.get('isExpanded')) {
       Ember.run.next(this, () => {
         let $container = this.$('.dp-month-body');
-        let $scrollTo = this.$(`button.dp-month-option:contains("${this.get('month').format('MMM')}")`);
-        if ($container && $container.length &&
-            $scrollTo && $scrollTo.length) {
+        let month = this.get('month');
+        if (!month) {
+          return;
+        }
 
+        let $scrollTo = this.$(`button.dp-month-option:contains("${month.format('MMM')}")`);
+        if ($container && $container.length && $scrollTo && $scrollTo.length) {
           $container.scrollTop(
             $scrollTo.offset().top - $container.offset().top + $container.scrollTop()
           );

--- a/addon/pods/year-display/component.js
+++ b/addon/pods/year-display/component.js
@@ -20,7 +20,7 @@ export default Component.extend({
   didRender() {
     if (this.get('isExpanded')) {
       run.next(this, () => {
-        let year = this.get('insideYearPicker') && this.get('startDate') ? this.get('startDate').year() : this.get('month').year();
+        let year = this._deduceYear();
         let $container = this.$('.dp-year-body');
         let $scrollTo = this.$(`button.dp-btn-year-option:contains(${year})`);
         if ($container && $container.length && $scrollTo && $scrollTo.length) {
@@ -33,6 +33,14 @@ export default Component.extend({
           }
       });
     }
+  },
+
+  _deduceYear() {
+    if (this.get('insideYearPicker') && this.get('startDate')) {
+      this.get('startDate').year();
+    }
+    let month = this.get('month');
+    month ? month.year() : moment().year();
   },
 
   allYears: computed('startDate', 'insideYearPicker', 'allYearsOffset', 'month', function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-date-range-picker",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Ember addon that provides various date pickers.",
   "directories": {
     "doc": "doc",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2419,11 +2419,11 @@ ember-inputmask@^0.4.0-beta.3:
     fastboot-transform "^0.1.1"
     inputmask "3.3.6"
 
-ember-keyboard@2.1.10:
-  version "2.1.10"
-  resolved "https://registry.yarnpkg.com/ember-keyboard/-/ember-keyboard-2.1.10.tgz#b885a572a560c52b9d52a1053c59d548d4100fbe"
+ember-keyboard@2.1.11:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/ember-keyboard/-/ember-keyboard-2.1.11.tgz#7aacfe00475b87a45a5376ced4f7ddc285211313"
   dependencies:
-    ember-cli-babel "^5.1.6"
+    ember-cli-babel "^6.3.0"
 
 ember-load-initializers@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes issues in `month-display` where if the `month` is null, auto-scrolling and setting a new month will cause breakage. This is do to trying to manipulate `null` as if it were a moment object.