### PR TITLE
fix(package): update ember-click-outside to version 1.0.0-beta.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-sass": "7.1.3",
-    "ember-click-outside": "^0.1.3",
+    "ember-click-outside": "^1.0.0-beta.6",
     "ember-inputmask": "^0.6.0",
     "ember-keyboard": "3.0.1",
     "ember-moment": "7.7.0",


### PR DESCRIPTION
Closes #270